### PR TITLE
Add privacy hard telemetry blocking

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -5,7 +5,7 @@
 max-struct-bools = 10
 
 # Set MSRV to ensure compatibility
-msrv = "1.75.0"
+msrv = "1.85.0"
 
 # Configure literal format options
 unreadable-literal-lint-fractions = false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,32 +48,128 @@ jobs:
       - name: Install cargo-make
         uses: davidB/rust-cargo-make@v1
 
+      - name: Resolve CEF binary
+        id: resolve-cef
+        env:
+          CEF_PLATFORM: linux64
+          CEF_CHANNEL: stable
+          CEF_FILE_TYPE: standard
+        run: |
+          python3 <<'PY' > "$RUNNER_TEMP/cef.env"
+          import json
+          import os
+          import sys
+          import urllib.parse
+          import urllib.request
+          from datetime import datetime, timedelta, timezone
+
+          platform = os.environ["CEF_PLATFORM"]
+          channel = os.environ["CEF_CHANNEL"]
+          file_type = os.environ["CEF_FILE_TYPE"]
+
+          def branch(build):
+              return int(build["chromium_version"].split(".")[2])
+
+          def is_beta(build):
+              return "_beta" in build["files"][0]["name"]
+
+          def current_stable(versions):
+              depth = 5
+              selected = None
+              selected_branch = 0
+              for build in versions:
+                  if is_beta(build):
+                      continue
+                  build_branch = branch(build)
+                  if build_branch > selected_branch:
+                      selected = build
+                      selected_branch = build_branch
+                  depth -= 1
+                  if depth == 0:
+                      break
+              return selected
+
+          def current_beta(versions, stable_build):
+              stable_branch = branch(stable_build) if stable_build is not None else 0
+              max_age = timedelta(days=60)
+              now = datetime.now(timezone.utc)
+              for build in versions:
+                  if not is_beta(build):
+                      continue
+                  timestamp = datetime.fromisoformat(
+                      build["files"][0]["last_modified"].replace("Z", "+00:00")
+                  )
+                  if branch(build) > stable_branch and now - timestamp < max_age:
+                      return build
+                  break
+              return None
+
+          with urllib.request.urlopen("https://cef-builds.spotifycdn.com/index.json", timeout=60) as response:
+              builds = json.load(response)
+
+          versions = builds[platform]["versions"]
+          stable_build = current_stable(versions)
+          if channel == "stable":
+              selected_build = stable_build
+          elif channel == "beta":
+              selected_build = current_beta(versions, stable_build)
+          else:
+              sys.exit(f"Unsupported CEF channel: {channel}")
+
+          selected_file = None
+          if selected_build is not None:
+              selected_file = next(
+                  (
+                      file
+                      for file in selected_build["files"]
+                      if file["type"] == file_type and file["name"].endswith(".tar.bz2")
+                  ),
+                  None,
+              )
+
+          if selected_build is None or selected_file is None:
+              sys.exit(f"No {platform} {channel} {file_type} CEF binary found")
+
+          archive = selected_file["name"]
+          package = archive.removesuffix(".tar.bz2")
+          url = "https://cef-builds.spotifycdn.com/" + urllib.parse.quote(archive)
+
+          print(f"archive={archive}")
+          print(f"package={package}")
+          print(f"url={url}")
+          print(f"sha1={selected_file['sha1']}")
+          print(f"cef_version={selected_build['cef_version']}")
+          print(f"chromium_version={selected_build['chromium_version']}")
+          PY
+
+          cat "$RUNNER_TEMP/cef.env" >> "$GITHUB_OUTPUT"
+          cat "$RUNNER_TEMP/cef.env"
+
       - name: Cache CEF binary
         id: cache-cef
         uses: actions/cache@v4
         with:
-          path: cef_binary_*.tar.bz2
-          key: cef-137.0.19-g8a1c4ce-chromium-137.0.7151.121-linux64
+          path: ${{ steps.resolve-cef.outputs.archive }}
+          key: cef-${{ steps.resolve-cef.outputs.archive }}
 
       - name: Download and extract CEF binary
         run: |
-          CEF_VERSION="137.0.19+g8a1c4ce+chromium-137.0.7151.121"
-          CEF_PACKAGE="cef_binary_${CEF_VERSION}_linux64"
-          CEF_URL="https://cef-builds.spotifycdn.com/cef_binary_137.0.19%2Bg8a1c4ce%2Bchromium-137.0.7151.121_linux64.tar.bz2"
+          CEF_ARCHIVE="${{ steps.resolve-cef.outputs.archive }}"
+          CEF_PACKAGE="${{ steps.resolve-cef.outputs.package }}"
+          CEF_URL="${{ steps.resolve-cef.outputs.url }}"
+          CEF_SHA1="${{ steps.resolve-cef.outputs.sha1 }}"
 
-          if [ ! -f "${CEF_PACKAGE}.tar.bz2" ]; then
+          if [ ! -f "${CEF_ARCHIVE}" ]; then
             echo "Downloading CEF binary..."
-            curl -L -f -o "${CEF_PACKAGE}.tar.bz2" "${CEF_URL}" || {
-              echo "Failed to download CEF. Trying to fetch available versions..."
-              curl -s "https://cef-builds.spotifycdn.com/index.json" | grep -o '"cef_version":"[^"]*137[^"]*"' | head -5
-              exit 1
-            }
+            curl -L -f --retry 3 --retry-delay 5 -o "${CEF_ARCHIVE}" "${CEF_URL}"
           else
             echo "Using cached CEF binary"
           fi
 
+          echo "${CEF_SHA1}  ${CEF_ARCHIVE}" | sha1sum -c -
+
           echo "Extracting CEF binary..."
-          tar -xjf "${CEF_PACKAGE}.tar.bz2"
+          tar -xjf "${CEF_ARCHIVE}"
 
           echo "CEF_ROOT=$PWD/${CEF_PACKAGE}" >> $GITHUB_ENV
           echo "CEF extracted to: $PWD/${CEF_PACKAGE}"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ $ export CEF_ROOT="$PWD/cef_binary_150.0.1+g3f36c80+chromium-150.0.7871.4_linux6
 $ cargo build --release --lib
 ```
 
+**Privacy hard build:**
+```bash
+$ export CEF_ROOT="$PWD/cef_binary_150.0.1+g3f36c80+chromium-150.0.7871.4_linux64_beta"
+$ cargo build --release --lib -p spotify-adblock --features privacy-hard-blocking
+```
+
+This opt-in feature also blocks broad Spotify telemetry routes found in the IDA dump, including event-service, logging, event sender, pending events, stream reporting, remote config, and common capping traffic. It may affect Wrapped, listening history, recommendations, or diagnostics.
+
 ## Install
 ```bash
 # Using traditional Make

--- a/cef-sys/build.rs
+++ b/cef-sys/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn main() {
     let cef_root =
@@ -53,7 +53,7 @@ fn main() {
 
     // Create wrapper header that includes all CEF C API headers
     let wrapper_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("cef_wrapper.h");
-    let wrapper_content = create_wrapper_header();
+    let wrapper_content = create_wrapper_header(&cef_path);
     fs::write(&wrapper_path, wrapper_content).expect("Failed to write wrapper header");
 
     // Generate bindings with correct include paths
@@ -98,92 +98,105 @@ fn main() {
     println!("CEF bindings generated successfully!");
 }
 
-fn create_wrapper_header() -> String {
-    // Use the correct include paths that work with CEF's directory structure
-    r#"
+fn create_wrapper_header(cef_path: &Path) -> String {
+    const CEF_CAPI_HEADERS: &[&str] = &[
+        "include/capi/cef_base_capi.h",
+        "include/capi/cef_app_capi.h",
+        "include/capi/cef_client_capi.h",
+        "include/capi/cef_browser_capi.h",
+        "include/capi/cef_browser_process_handler_capi.h",
+        "include/capi/cef_render_process_handler_capi.h",
+        "include/capi/cef_life_span_handler_capi.h",
+        "include/capi/cef_load_handler_capi.h",
+        "include/capi/cef_display_handler_capi.h",
+        "include/capi/cef_context_menu_handler_capi.h",
+        "include/capi/cef_dialog_handler_capi.h",
+        "include/capi/cef_download_handler_capi.h",
+        "include/capi/cef_drag_handler_capi.h",
+        "include/capi/cef_find_handler_capi.h",
+        "include/capi/cef_focus_handler_capi.h",
+        "include/capi/cef_frame_handler_capi.h",
+        "include/capi/cef_jsdialog_handler_capi.h",
+        "include/capi/cef_keyboard_handler_capi.h",
+        "include/capi/cef_permission_handler_capi.h",
+        "include/capi/cef_print_handler_capi.h",
+        "include/capi/cef_render_handler_capi.h",
+        "include/capi/cef_request_handler_capi.h",
+        "include/capi/cef_resource_request_handler_capi.h",
+        "include/capi/cef_request_capi.h",
+        "include/capi/cef_response_capi.h",
+        "include/capi/cef_urlrequest_capi.h",
+        "include/capi/cef_cookie_capi.h",
+        "include/capi/cef_request_context_capi.h",
+        "include/capi/cef_request_context_handler_capi.h",
+        "include/capi/cef_resource_handler_capi.h",
+        "include/capi/cef_response_filter_capi.h",
+        "include/capi/cef_scheme_capi.h",
+        "include/capi/cef_command_line_capi.h",
+        "include/capi/cef_process_message_capi.h",
+        "include/capi/cef_values_capi.h",
+        "include/capi/cef_frame_capi.h",
+        "include/capi/cef_image_capi.h",
+        "include/capi/cef_menu_model_capi.h",
+        "include/capi/cef_dom_capi.h",
+        "include/capi/cef_v8_capi.h",
+        "include/capi/cef_callback_capi.h",
+        "include/capi/cef_task_capi.h",
+        "include/capi/cef_thread_capi.h",
+        "include/capi/cef_waitable_event_capi.h",
+        "include/capi/cef_trace_capi.h",
+        "include/capi/cef_file_util_capi.h",
+        "include/capi/cef_path_util_capi.h",
+        "include/capi/cef_process_util_capi.h",
+        "include/capi/cef_stream_capi.h",
+        "include/capi/cef_string_visitor_capi.h",
+        "include/capi/cef_zip_reader_capi.h",
+        "include/capi/cef_xml_reader_capi.h",
+        "include/capi/cef_accessibility_handler_capi.h",
+        "include/capi/cef_audio_handler_capi.h",
+        "include/capi/cef_auth_callback_capi.h",
+        "include/capi/cef_command_handler_capi.h",
+        "include/capi/cef_component_updater_capi.h",
+        "include/capi/cef_devtools_message_observer_capi.h",
+        "include/capi/cef_download_item_capi.h",
+        "include/capi/cef_drag_data_capi.h",
+        "include/capi/cef_i18n_util_capi.h",
+        "include/capi/cef_media_router_capi.h",
+        "include/capi/cef_menu_model_delegate_capi.h",
+        "include/capi/cef_navigation_entry_capi.h",
+        "include/capi/cef_origin_whitelist_capi.h",
+        "include/capi/cef_parser_capi.h",
+        "include/capi/cef_preference_capi.h",
+        "include/capi/cef_print_settings_capi.h",
+        "include/capi/cef_registration_capi.h",
+        "include/capi/cef_resource_bundle_capi.h",
+        "include/capi/cef_resource_bundle_handler_capi.h",
+        "include/capi/cef_server_capi.h",
+        "include/capi/cef_shared_memory_region_capi.h",
+        "include/capi/cef_shared_process_message_builder_capi.h",
+        "include/capi/cef_ssl_info_capi.h",
+        "include/capi/cef_ssl_status_capi.h",
+        "include/capi/cef_task_manager_capi.h",
+        "include/capi/cef_unresponsive_process_callback_capi.h",
+        "include/capi/cef_x509_certificate_capi.h",
+        "include/capi/cef_crash_util_capi.h",
+    ];
+
+    let mut wrapper = String::from(
+        r#"
 // CEF C API Wrapper Header for Rust Bindings
 
 // Include all main CEF C API headers using paths relative to CEF root
-#include "include/capi/cef_base_capi.h"
-#include "include/capi/cef_app_capi.h"
-#include "include/capi/cef_client_capi.h"
-#include "include/capi/cef_browser_capi.h"
-#include "include/capi/cef_browser_process_handler_capi.h"
-#include "include/capi/cef_render_process_handler_capi.h"
-#include "include/capi/cef_life_span_handler_capi.h"
-#include "include/capi/cef_load_handler_capi.h"
-#include "include/capi/cef_display_handler_capi.h"
-#include "include/capi/cef_context_menu_handler_capi.h"
-#include "include/capi/cef_dialog_handler_capi.h"
-#include "include/capi/cef_download_handler_capi.h"
-#include "include/capi/cef_drag_handler_capi.h"
-#include "include/capi/cef_find_handler_capi.h"
-#include "include/capi/cef_focus_handler_capi.h"
-#include "include/capi/cef_frame_handler_capi.h"
-#include "include/capi/cef_jsdialog_handler_capi.h"
-#include "include/capi/cef_keyboard_handler_capi.h"
-#include "include/capi/cef_permission_handler_capi.h"
-#include "include/capi/cef_print_handler_capi.h"
-#include "include/capi/cef_render_handler_capi.h"
-#include "include/capi/cef_request_handler_capi.h"
-#include "include/capi/cef_resource_request_handler_capi.h"
-#include "include/capi/cef_request_capi.h"
-#include "include/capi/cef_response_capi.h"
-#include "include/capi/cef_urlrequest_capi.h"
-#include "include/capi/cef_cookie_capi.h"
-#include "include/capi/cef_request_context_capi.h"
-#include "include/capi/cef_request_context_handler_capi.h"
-#include "include/capi/cef_resource_handler_capi.h"
-#include "include/capi/cef_response_filter_capi.h"
-#include "include/capi/cef_scheme_capi.h"
-#include "include/capi/cef_command_line_capi.h"
-#include "include/capi/cef_process_message_capi.h"
-#include "include/capi/cef_values_capi.h"
-#include "include/capi/cef_frame_capi.h"
-#include "include/capi/cef_image_capi.h"
-#include "include/capi/cef_menu_model_capi.h"
-#include "include/capi/cef_dom_capi.h"
-#include "include/capi/cef_v8_capi.h"
-#include "include/capi/cef_callback_capi.h"
-#include "include/capi/cef_task_capi.h"
-#include "include/capi/cef_thread_capi.h"
-#include "include/capi/cef_waitable_event_capi.h"
-#include "include/capi/cef_trace_capi.h"
-#include "include/capi/cef_file_util_capi.h"
-#include "include/capi/cef_path_util_capi.h"
-#include "include/capi/cef_process_util_capi.h"
-#include "include/capi/cef_stream_capi.h"
-#include "include/capi/cef_string_visitor_capi.h"
-#include "include/capi/cef_zip_reader_capi.h"
-#include "include/capi/cef_xml_reader_capi.h"
-#include "include/capi/cef_accessibility_handler_capi.h"
-#include "include/capi/cef_audio_handler_capi.h"
-#include "include/capi/cef_auth_callback_capi.h"
-#include "include/capi/cef_command_handler_capi.h"
-#include "include/capi/cef_component_updater_capi.h"
-#include "include/capi/cef_devtools_message_observer_capi.h"
-#include "include/capi/cef_download_item_capi.h"
-#include "include/capi/cef_drag_data_capi.h"
-#include "include/capi/cef_i18n_util_capi.h"
-#include "include/capi/cef_media_router_capi.h"
-#include "include/capi/cef_menu_model_delegate_capi.h"
-#include "include/capi/cef_navigation_entry_capi.h"
-#include "include/capi/cef_origin_whitelist_capi.h"
-#include "include/capi/cef_parser_capi.h"
-#include "include/capi/cef_preference_capi.h"
-#include "include/capi/cef_print_settings_capi.h"
-#include "include/capi/cef_registration_capi.h"
-#include "include/capi/cef_resource_bundle_capi.h"
-#include "include/capi/cef_resource_bundle_handler_capi.h"
-#include "include/capi/cef_server_capi.h"
-#include "include/capi/cef_shared_memory_region_capi.h"
-#include "include/capi/cef_shared_process_message_builder_capi.h"
-#include "include/capi/cef_ssl_info_capi.h"
-#include "include/capi/cef_ssl_status_capi.h"
-#include "include/capi/cef_task_manager_capi.h"
-#include "include/capi/cef_unresponsive_process_callback_capi.h"
-#include "include/capi/cef_x509_certificate_capi.h"
-#include "include/capi/cef_crash_util_capi.h"
-"#
-    .to_string()
+"#,
+    );
+
+    for header in CEF_CAPI_HEADERS {
+        if cef_path.join(header).exists() {
+            wrapper.push_str("#include \"");
+            wrapper.push_str(header);
+            wrapper.push_str("\"\n");
+        }
+    }
+
+    wrapper
 }

--- a/config.toml
+++ b/config.toml
@@ -133,5 +133,6 @@ denylist = [
     '.*pubads\.google\.com/ad.*',
     '.*googleads\..*',
     '.*adswizz\..*',
-    '.*/v1/podcast/nextAdSegment.*',
+    'https://spclient\.wg\.spotify\.com/v1/podcast/nextAdSegment.*',
+    'https://[^/]*-spclient\.spotify\.com/v1/podcast/nextAdSegment.*',
 ]

--- a/config.toml
+++ b/config.toml
@@ -118,6 +118,7 @@ denylist = [
     'https://spclient\.wg\.spotify\.com/.*/partner/.*',
     'https://api-partner\.spotify\.com/promotion/.*',
     'https://open\.spotify\.com/promotion/.*',
+    'https://spclient\.wg\.spotify\.com/.*/partner-userid/encrypted/.*',
 
     # Display segments (sponsored playlist banners, "presented by" banners)
     'https://spclient\.wg\.spotify\.com/display-segments/.*',
@@ -132,4 +133,5 @@ denylist = [
     '.*pubads\.google\.com/ad.*',
     '.*googleads\..*',
     '.*adswizz\..*',
+    '.*/v1/podcast/nextAdSegment.*',
 ]

--- a/spotify-adblock/Cargo.toml
+++ b/spotify-adblock/Cargo.toml
@@ -23,6 +23,10 @@ cef-sys = { path = "../cef-sys" }
 name = "spotifyadblock"
 crate-type = ["cdylib"]
 
+[features]
+default = []
+privacy-hard-blocking = []
+
 # Inherit workspace lints
 [lints]
 workspace = true

--- a/spotify-adblock/src/hooks/mod.rs
+++ b/spotify-adblock/src/hooks/mod.rs
@@ -2,6 +2,7 @@ pub mod memory;
 pub mod network;
 mod request_classification;
 pub mod requests;
+mod rules;
 pub mod ssl;
 
 pub use memory::*;

--- a/spotify-adblock/src/hooks/request_classification.rs
+++ b/spotify-adblock/src/hooks/request_classification.rs
@@ -2,8 +2,6 @@
 
 use super::rules;
 
-const MAX_URL_LENGTH: usize = 2048;
-
 pub(super) struct UrlClassification {
     pub(super) is_discord_rpc: bool,
     pub(super) is_gabo: bool,
@@ -14,7 +12,6 @@ pub(super) struct UrlClassification {
 }
 
 pub(super) fn classify_url(url: &str, method: &str) -> UrlClassification {
-    let url = bounded_url(url);
     let is_gabo_event_post = is_gabo_event_post(url, method);
 
     UrlClassification {
@@ -25,18 +22,6 @@ pub(super) fn classify_url(url: &str, method: &str) -> UrlClassification {
         is_product_state: is_product_state(url),
         is_gabo_event_post,
     }
-}
-
-fn bounded_url(url: &str) -> &str {
-    if url.len() <= MAX_URL_LENGTH {
-        return url;
-    }
-
-    let mut cutoff = MAX_URL_LENGTH;
-    while !url.is_char_boundary(cutoff) {
-        cutoff -= 1;
-    }
-    &url[..cutoff]
 }
 
 fn is_discord_rpc(url: &str) -> bool {
@@ -71,17 +56,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bounded_url_truncates_at_utf8_boundary() {
-        let url = format!("{}é", "a".repeat(MAX_URL_LENGTH - 1));
-
-        assert_eq!(bounded_url(&url), "a".repeat(MAX_URL_LENGTH - 1));
-    }
-
-    #[test]
     fn gabo_event_post_does_not_get_service_allowance() {
         let classification = classify_url("https://gabo-receiver-service.spotify.com/events", "POST");
 
         assert!(classification.is_gabo_event_post);
         assert!(!classification.is_gabo);
+    }
+
+    #[test]
+    fn classification_checks_ad_markers_after_long_prefix() {
+        let url = format!("https://spclient.wg.spotify.com/{}/ads/foo", "a".repeat(4096));
+        let classification = classify_url(&url, "GET");
+
+        assert!(classification.is_ad_related);
     }
 }

--- a/spotify-adblock/src/hooks/request_classification.rs
+++ b/spotify-adblock/src/hooks/request_classification.rs
@@ -1,54 +1,9 @@
-#![allow(clippy::struct_excessive_bools, clippy::too_many_lines)]
+#![allow(clippy::struct_excessive_bools)]
 
-// Constants for fault containment
+use super::rules;
+
 const MAX_URL_LENGTH: usize = 2048;
 
-// COMPREHENSIVE AD BLOCKING COVERAGE (Surgical Approach + IDA Pro Validated)
-//
-// This implementation blocks Spotify ads at multiple layers based on reverse engineering
-// and IDA Pro binary analysis, using a SURGICAL approach that preserves core functionality:
-//
-// 1. **API Infrastructure**: Ad coordination, injection logic, Gabo events (2 variants)
-// 2. **Content Delivery**: Audio ad CDN paths (not entire CDN), video ads, creative assets
-// 3. **Metadata**: Track metadata injection, queue manipulation (ad-specific only)
-// 4. **Tracking**: Ad-specific analytics, attribution (branch.io, adjust.com), podcast tracking
-// 5. **Podcast Ads**: Megaphone.fm, art19.com, chartable.com, podsights.com + segment API
-// 6. **Display Ads**: Sponsor banners, playlist decorations, companion content
-// 7. **Enforcement**: Skip limits, ad-specific license checks (preserves premium validation)
-// 8. **Third-Party Networks**: DoubleClick, Google Ads, Adswizz
-// 9. **Ad Event System**: AdEvent, AdOpportunity, AdDecision, EndAd (from protobuf)
-// 10. **Ad Pod System**: AdPodResponse, AdDecisionTree (from IDA decompilation)
-// 11. **Esperanto Ad Services**: spotify.ads.esperanto.proto (Targeting, AdOpportunity, Events)
-// 12. **Ad Attribution**: Branch.io tracking, partner user ID sharing (IDA validated)
-// 13. **Privacy Protection**: Concert location tracking blocked (concert_location_extension.proto)
-//
-// IDA PRO VALIDATED PATTERNS:
-// - "injected-ad" track type classification (confirmed at 0x55C4D77538D0)
-// - Gabo endpoints: /v3/events/ and /public/v3/events/ (confirmed at 0x55C4D8699CF0)
-// - Ad opportunity proto system (AdOpportunityEvent.proto)
-// - Podcast ad segments (PodcastAdSegmentReceived.proto)
-// - Audio ad event reporter (audio_ad_event_reporter)
-// - Branch.io controller (desktop/shell/desktop/ads_tracking/cpp/src/branch_io_controller_impl.cpp)
-// - Partner user ID fetcher (desktop/shell/desktop/ads_tracking/cpp/src/partner_user_id_fetcher.cpp)
-// - Concert location extension (concert_location_extension.proto at 0x55C4D78C1999)
-// - Esperanto ad services (spotify.ads.esperanto.proto.AdOpportunity, Targeting, Events)
-// - Stream reporting (only ad-specific, preserves Wrapped/stats)
-// - Device capabilities URL builder (sub_55C4D794A9C0 - device_brand only blocked in ad context)
-// - Client settings API (only blocks when combined with ad/sponsor keywords)
-//
-// CRITICAL ALLOWLIST (never blocked):
-// - Premium subscription validation (/user/product, /subscription/validate)
-// - License user checks (/license/user)
-// - Product state fetching (needed for premium verification)
-// - General analytics (Wrapped, listening stats, recommendations)
-//
-// Known limitations (cannot be blocked at CEF URL level):
-// - Baked-in podcast ads (already in audio file)
-// - Server-side stitched ads (inserted before delivery)
-// - Host-read sponsorships (part of podcast content)
-//
-// Estimated coverage: 96-99% of dynamic ads (IDA-validated, zero feature breakage).
-// URL classification with bounded execution and radiation hardening
 pub(super) struct UrlClassification {
     pub(super) is_discord_rpc: bool,
     pub(super) is_gabo: bool,
@@ -58,365 +13,50 @@ pub(super) struct UrlClassification {
     pub(super) is_gabo_event_post: bool,
 }
 
-// Fault-contained URL classifier with bounded execution
 pub(super) fn classify_url(url: &str, method: &str) -> UrlClassification {
-    // Ensure URL is within reasonable bounds (fault containment)
-    let url = if url.len() > MAX_URL_LENGTH {
+    let url = bounded_url(url);
+
+    UrlClassification {
+        is_discord_rpc: is_discord_rpc(url),
+        is_gabo: is_allowed_gabo_service(url),
+        is_dealer: url.contains("dealer"),
+        is_ad_related: rules::is_ad_related_url(url),
+        is_product_state: is_product_state(url),
+        is_gabo_event_post: is_gabo_event_post(url, method),
+    }
+}
+
+fn bounded_url(url: &str) -> &str {
+    if url.len() > MAX_URL_LENGTH {
         &url[0..MAX_URL_LENGTH]
     } else {
         url
-    };
-
-    UrlClassification {
-        is_discord_rpc: url.contains("discord")
-            || url.contains("discordapp")
-            || url.contains("presence")
-            || url.contains("/presence2/")
-            || url.contains("connect-state")
-            || url.contains("rpc"),
-
-        // Gabo service - ONLY allow non-ad events
-        is_gabo: url.contains("gabo-receiver-service")
-            && !url.contains("/advertisement")
-            && !url.contains("/ad-opportunity")
-            && !url.contains("/adlogic")
-            && !url.contains("/ads")
-            && !url.contains("/v3/events/")
-            && !url.contains("/public/v3/events/"),
-
-        // Gabo POST payloads can carry ad data without an ad marker in the URL.
-        is_gabo_event_post: url.contains("gabo-receiver-service")
-            && url.contains("/events")
-            && method == "POST",
-
-        is_dealer: url.contains("dealer"),
-
-        // Product state monitoring (for premium checks)
-        is_product_state: url.contains("product_state") || url.contains("product-state"),
-
-        // COMPREHENSIVE ad detection criteria
-        is_ad_related: {
-            // === CRITICAL ALLOWLIST - NEVER BLOCK THESE ===
-            // These endpoints are essential for premium validation and core functionality
-            if url.contains("/license/user")
-                || url.contains("/product_state/get")
-                || url.contains("/subscription/status")
-                || url.contains("/user/product")
-                || url.contains("/subscription/validate")
-            {
-                false // Explicitly allow premium validation
-            } else {
-                // === CORE AD ENDPOINTS ===
-                url.contains("/ads/") ||
-            url.contains("sp://ads/v1/ads/") ||
-            url.contains("/v1/ads/") ||
-            url.contains("ad-logic") ||
-            url.contains("adlogic") ||
-            url.contains("adsegments") ||
-            url.contains("/adrequest") ||
-            url.contains("/ad-request") ||
-            url.contains("spotify.ads.esperanto.proto.") ||
-            url.contains("spotify.ads.proto.") ||
-            url.contains("VND.Spotify.Ads-Payload") ||
-
-            // CRITICAL: Track classification marker (from reverse engineering)
-            url.contains("injected-ad") ||
-
-            // === AUDIO AD CDN ENDPOINTS ===
-            // CRITICAL: Only block CDN paths with ad-specific patterns, not entire CDN
-            // (CDN serves both music AND ads - must be path-specific)
-            (url.contains("audio-fa.scdn.co") && (
-                url.contains("/ad/") ||
-                url.contains("/ads/") ||
-                url.contains("_ad_") ||
-                url.contains("/sponsored/")
-            )) ||
-            (url.contains("audio-ak.spotify.com.edgesuite.net") && url.contains("/ad")) ||
-            (url.contains("audio-ak-spotify-com") && url.contains("/ad")) ||
-            url.contains("/ad_audio/") ||
-            url.contains("/sponsored_audio/") ||
-
-            // === SPOTIFY AD DOMAINS ===
-            url.contains("ads.spotify.com") ||
-            url.contains("adstudio.spotify.com") ||
-            url.contains("audio-ads.spotify.com") ||
-            url.contains("creativeservice-production") ||
-
-            // === THIRD-PARTY AD NETWORKS ===
-            url.contains("pubads.google.com/ad") ||
-            url.contains("doubleclick") ||
-            url.contains("googleads") ||
-            url.contains("adswizz") ||
-
-            // === PODCAST AD SYSTEMS ===
-            // Spotify's primary podcast ad platform
-            url.contains("megaphone.fm") ||
-            // Secondary podcast ad network
-            url.contains("art19.com") ||
-            // Simplecast podcast ads (only episode segments)
-            (url.contains("simplecast.com") && url.contains("episodes")) ||
-
-            // === PODCAST TRACKING & ANALYTICS ===
-            // Podcast analytics/attribution
-            url.contains("chartable.com") ||
-            url.contains("podsights.com") ||
-            url.contains("podscribe.com") ||
-
-            // === ANALYTICS & ATTRIBUTION TRACKING ===
-            // ONLY block ad-specific analytics (not general listening stats/Wrapped/etc)
-            (url.contains("analytics") && (
-                url.contains("ad") ||
-                url.contains("sponsor") ||
-                url.contains("promotion")
-            )) ||
-            // Branch.io attribution (discovered in reverse engineering)
-            url.contains("branch.io") ||
-            url.contains("app.link") ||  // Branch.io deep links
-            // Additional mobile attribution platforms
-            url.contains("adjust.com") ||
-            url.contains("kochava.com") ||
-            // Client settings API - ONLY block when combined with ad-related keywords
-            // (Allows user preferences like equalizer, quality settings to sync)
-            (url.contains("clientsettings") && url.contains("api") && (
-                url.contains("ad") ||
-                url.contains("sponsor") ||
-                url.contains("promotion")
-            )) ||
-            (url.contains("track") && url.contains("event") && url.contains("ad")) ||
-
-            // === SPONSORED/PROMOTED CONTENT ===
-            url.contains("sponsor") ||
-            url.contains("/promotion/") ||
-            url.contains("spotify:promotion:") ||
-            url.contains("/partner/") ||
-            url.contains("spotify:partner:") ||
-            url.contains("partnership") ||
-            url.contains("promoted") ||
-
-            // === DISPLAY ADS & COMPANION CONTENT ===
-            url.contains("companion-ad") ||
-            url.contains("companion_content") ||
-            url.contains("companion-content") ||
-            url.contains("canvas_ad") ||
-            url.contains("canvas-ad") ||
-            url.contains("/figs/") ||
-
-            // === VIDEO ADS & CANVAS ===
-            url.contains("video-ad") ||
-            url.contains("videoad") ||
-            url.contains("/ad.mp4") ||
-            url.contains("/ads.mp4") ||
-            // Canvas video ads (from protobuf CanvasVideo/CanvasImage)
-            (url.contains("/canvas/") && url.contains("ad")) ||
-            url.contains("video-fa.scdn.co") ||
-            url.contains("canvasVideo") ||
-
-            // === AD CREATIVE & ASSET DELIVERY ===
-            url.contains("ad-creative") ||
-            url.contains("ad_creative") ||
-
-            // === SKIP LIMIT ENFORCEMENT ===
-            url.contains("RemainingSkipsRequest") ||
-            url.contains("RemainingSkipsResponse") ||
-            url.contains("skip-limit") ||
-            url.contains("skip_limit") ||
-
-            // === DISPLAY SEGMENTS (sponsored playlist banners) ===
-            // ONLY block ad-specific segments (service used for all UI display)
-            ((url.contains("display-segments") || url.contains("display_segments") || url.contains("DisplaySegments")) && (
-                url.contains("sponsor") ||
-                url.contains("promoted") ||
-                url.contains("ad")
-            )) ||
-
-            // === TRACK METADATA & QUEUE MANIPULATION ===
-            // Where "injected-ad" track type gets set
-            (url.contains("/track-metadata") && url.contains("ad")) ||
-            (url.contains("/resolve") && url.contains("spotify:ad:")) ||
-            (url.contains("/metadata") && url.contains("injected")) ||
-            (url.contains("/queue/add") && url.contains("ad")) ||
-            // ONLY block playlist modifications related to ad injection
-            (url.contains("/playlist/modify") && (
-                url.contains("ad") ||
-                url.contains("injected") ||
-                url.contains("sponsor")
-            )) ||
-
-            // === PLAYLIST BANNER/DECORATION ENDPOINTS ===
-            // "Presented by" sponsor branding
-            url.contains("/playlist/decoration") ||
-            url.contains("/playlist/branding") ||
-            url.contains("/playlist/sponsor-info") ||
-            (url.contains("/v1/views/") && url.contains("sponsored")) ||
-
-            // Banner image CDN endpoints
-            (url.contains("i.scdn.co") && url.contains("sponsor")) ||
-            (url.contains("mosaic.scdn.co") && url.contains("promo")) ||
-
-            // === LICENSE VALIDATION & ENTITLEMENT ===
-            // CRITICAL: Only block ad-specific license checks, NOT premium validation
-            // (Must allow Spotify to verify premium status or account may be flagged)
-            (url.contains("/license/") && url.contains("ad")) ||
-            (url.contains("/entitlement/") && (
-                url.contains("ad") ||
-                url.contains("sponsor")
-            )) ||
-            // DO NOT block general subscription/product validation - needed for premium
-            // url.contains("/subscription/validate") - REMOVED (too dangerous)
-            // url.contains("/user/product") - REMOVED (master premium gatekeeper)
-
-            // === PLAYBACK RESTRICTIONS & SKIP LIMITS ===
-            url.contains("/v1/me/player/skip-limits") ||
-            url.contains("/skip-counter") ||
-            url.contains("/playback/restrictions") ||
-
-            // === GABO AD EVENTS (comprehensive blocking from IDA analysis) ===
-            // Gabo has TWO endpoint variants discovered in binary:
-            //   1. gabo-receiver-service/v3/events/
-            //   2. gabo-receiver-service/public/v3/events/
-            (url.contains("gabo-receiver-service") && (
-                url.contains("/advertisement") ||
-                url.contains("/ad-opportunity") ||  // AdOpportunityEvent.proto
-                url.contains("/adlogic") ||
-                url.contains("/ads") ||
-                url.contains("/v3/events/") ||      // Main Gabo events endpoint
-                url.contains("/public/v3/events/")  // Public Gabo events variant
-            )) ||
-
-            // === AD EVENT REPORTING (from IDA proto analysis) ===
-            // Audio ad event reporter system
-            url.contains("audio_ad_event_reporter") ||
-            url.contains("/AdEvent") ||
-            url.contains("/EndAd") ||
-            url.contains("/AdDecisionEvent") ||
-            url.contains("/AdRequestEvent") ||
-            url.contains("/AdTransparencyEvent") ||
-            url.contains("/AdDetectionResult") ||
-
-            // === PODCAST AD SEGMENTS (from IDA) ===
-            url.contains("/PodcastAdSegment") ||
-            url.contains("/GetNextAdSegment") ||
-            url.contains("AdSegmentsMetadataReceived") ||
-
-            // === AD POD & DECISION TREE ===
-            url.contains("/AdPodResponse") ||
-            url.contains("/AdDecisionTree") ||
-
-            // === ESPERANTO AD SERVICES (from IDA binary analysis) ===
-            // Spotify's internal RPC framework for ads/tracking
-            (url.contains("esperanto") && (
-                url.contains("/ads/") ||
-                url.contains("/Ads") ||
-                url.contains("AdOpportunity") ||
-                url.contains("PodcastAds") ||
-                url.contains("/Targeting") ||
-                url.contains("/ad-") ||
-                url.contains("_ad_")
-            )) ||
-
-            // === AD TRACKING & ATTRIBUTION (IDA validated) ===
-            // Branch.io controller (desktop/shell/desktop/ads_tracking/cpp/src/branch_io_controller_impl.cpp)
-            url.contains("/branch_io") ||
-            url.contains("/branchIo") ||
-            url.contains("branch-io") ||
-
-            // Partner user ID sharing (desktop/shell/desktop/ads_tracking/cpp/src/partner_user_id_fetcher.cpp)
-            url.contains("/partner_user_id") ||
-            url.contains("/partner-user-id") ||
-            url.contains("partnerUserId") ||
-
-            // === STREAM REPORTING (IDA proto: spotify.stream_reporting_esperanto.proto) ===
-            // CRITICAL: Only block ad-specific stream reporting, NOT general playback stats
-            // (General stream reporting needed for Wrapped, stats, recommendations)
-            (url.contains("stream_reporting") && (
-                url.contains("ad") ||
-                url.contains("sponsor") ||
-                url.contains("promotion")
-            )) ||
-            (url.contains("stream-reporting") && (
-                url.contains("ad") ||
-                url.contains("sponsor")
-            )) ||
-
-            // === CONCERT LOCATION TRACKING (IDA proto: concert_location_extension.proto at 0x55C4D78C1999) ===
-            // Physical location tracking for concert attendance
-            url.contains("concert_location") ||
-            url.contains("concert-location") ||
-            url.contains("concertLocation") ||
-
-            url.contains("leavebehind") ||
-            url.contains("leave-behind") ||
-            url.contains("leave_behind") ||
-            url.contains("podcast-ap4p/leavebehind") ||
-            url.contains("podcast-ap4p/leavebehinds") ||
-            url.contains("podcast-ap4p") ||
-            url.contains("/ap4p/") ||
-            url.contains("sponsoredplaylist") ||
-            url.contains("aet.spotify.com") ||
-            (url.contains("graphql") && (
-                url.contains("leavebehind") ||
-                url.contains("getLeavebehind") ||
-                url.contains("GetLeavebehind")
-            )) ||
-            url.contains("USE_GET_LEAVEBEHIND_ADS") ||
-            url.contains("leavebehindAds") ||
-            url.contains("leavebehinds-wrapper") ||
-            url.contains("leavebehinds-list") ||
-
-            // === MISC AD-RELATED ===
-            // CRITICAL: Only block "brand" in ad/sponsor context, NOT device_brand
-            // (device_brand is used for hardware capability detection)
-            ((url.contains("brand") || url.contains("branding")) && (
-                url.contains("/sponsor") ||
-                url.contains("/promotion") ||
-                url.contains("/partner") ||
-                url.contains("/playlist") ||  // Playlist branding/decoration
-                url.contains("/ad")
-            )) ||
-            url.contains("whatsapp") ||
-            url.contains("hpto") ||
-            url.contains("takeover") ||
-
-            // === IDA PRO DISCOVERED PATTERNS (2024 Binary Analysis) ===
-            // Direct ad content URLs (found in binary strings)
-            url.contains("open.spotify.com/ad/") ||
-            url.contains("spotify:ad:") ||
-
-            // Interruption ads (found at 0x5643C8824668)
-            url.contains("open.spotify.com/interruption/") ||
-            url.contains("spotify:interruption:") ||
-
-            // Promotion URLs (found at 0x5643C880B475)
-            url.contains("open.spotify.com/promotion/") ||
-
-            // Sponsored podcast content (from IDA proto analysis)
-            url.contains("contains_sponsored_content") ||
-            url.contains("SponsoredContentListenerPayload") ||
-            url.contains("PODCAST_SPONSORED_CONTENT") ||
-
-            // Ad slot management (from IDA analysis)
-            url.contains("slot_has_active_ad") ||
-            url.contains("slot_fetching_turned_off") ||
-            url.contains("PrepareSlotRequest") ||
-
-            // Ad pod response system (from IDA proto)
-            url.contains("AdPodResponse") ||
-            url.contains("SlotRealtimeDecisions") ||
-
-            // Audio ad event reporter (from IDA: audio_ad_event_reporter)
-            url.contains("audio_ad_event") ||
-
-            // Ad tracking pixels and viewability
-            url.contains("viewable_impression") ||
-            url.contains("fire_impression_on_end") ||
-            url.contains("tracking_events") ||
-            url.contains("trackingEvents") ||
-
-            // Promo traits (from IDA strings)
-            url.contains("PROMO_V1_TRAIT") ||
-            url.contains("PROMO_V3_TRAIT") ||
-            url.contains("AUDIOBOOK_PROMOTION")
-            } // End of else block
-        }, // End of is_ad_related
     }
+}
+
+fn is_discord_rpc(url: &str) -> bool {
+    url.contains("discord")
+        || url.contains("discordapp")
+        || url.contains("presence")
+        || url.contains("/presence2/")
+        || url.contains("connect-state")
+        || url.contains("rpc")
+}
+
+fn is_allowed_gabo_service(url: &str) -> bool {
+    url.contains("gabo-receiver-service")
+        && !url.contains("/advertisement")
+        && !url.contains("/ad-opportunity")
+        && !url.contains("/adlogic")
+        && !url.contains("/ads")
+        && !url.contains("/v3/events/")
+        && !url.contains("/public/v3/events/")
+}
+
+fn is_gabo_event_post(url: &str, method: &str) -> bool {
+    url.contains("gabo-receiver-service") && url.contains("/events") && method == "POST"
+}
+
+fn is_product_state(url: &str) -> bool {
+    url.contains("product_state") || url.contains("product-state")
 }

--- a/spotify-adblock/src/hooks/request_classification.rs
+++ b/spotify-adblock/src/hooks/request_classification.rs
@@ -15,23 +15,28 @@ pub(super) struct UrlClassification {
 
 pub(super) fn classify_url(url: &str, method: &str) -> UrlClassification {
     let url = bounded_url(url);
+    let is_gabo_event_post = is_gabo_event_post(url, method);
 
     UrlClassification {
         is_discord_rpc: is_discord_rpc(url),
-        is_gabo: is_allowed_gabo_service(url),
+        is_gabo: is_allowed_gabo_service(url) && !is_gabo_event_post,
         is_dealer: url.contains("dealer"),
         is_ad_related: rules::is_ad_related_url(url),
         is_product_state: is_product_state(url),
-        is_gabo_event_post: is_gabo_event_post(url, method),
+        is_gabo_event_post,
     }
 }
 
 fn bounded_url(url: &str) -> &str {
-    if url.len() > MAX_URL_LENGTH {
-        &url[0..MAX_URL_LENGTH]
-    } else {
-        url
+    if url.len() <= MAX_URL_LENGTH {
+        return url;
     }
+
+    let mut cutoff = MAX_URL_LENGTH;
+    while !url.is_char_boundary(cutoff) {
+        cutoff -= 1;
+    }
+    &url[..cutoff]
 }
 
 fn is_discord_rpc(url: &str) -> bool {
@@ -59,4 +64,24 @@ fn is_gabo_event_post(url: &str, method: &str) -> bool {
 
 fn is_product_state(url: &str) -> bool {
     url.contains("product_state") || url.contains("product-state")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_url_truncates_at_utf8_boundary() {
+        let url = format!("{}é", "a".repeat(MAX_URL_LENGTH - 1));
+
+        assert_eq!(bounded_url(&url), "a".repeat(MAX_URL_LENGTH - 1));
+    }
+
+    #[test]
+    fn gabo_event_post_does_not_get_service_allowance() {
+        let classification = classify_url("https://gabo-receiver-service.spotify.com/events", "POST");
+
+        assert!(classification.is_gabo_event_post);
+        assert!(!classification.is_gabo);
+    }
 }

--- a/spotify-adblock/src/hooks/rules/ad.rs
+++ b/spotify-adblock/src/hooks/rules/ad.rs
@@ -1,0 +1,238 @@
+use super::ida;
+use super::matchers::contains_any;
+use super::privacy;
+
+pub(in crate::hooks) fn is_ad_related_url(url: &str) -> bool {
+    !is_critical_allowlisted(url)
+        && (core_ad_endpoint(url)
+            || audio_ad_content(url)
+            || spotify_ad_domain(url)
+            || third_party_ad_network(url)
+            || podcast_ad_or_tracking(url)
+            || ad_specific_analytics(url)
+            || sponsored_or_promoted_content(url)
+            || display_video_or_creative_ad(url)
+            || skip_limit_or_restriction(url)
+            || display_segment_ad(url)
+            || metadata_queue_or_playlist_ad(url)
+            || entitlement_ad_check(url)
+            || gabo_ad_event(url)
+            || ida::is_ida_ad_signal(url)
+            || concert_location_tracking(url)
+            || leavebehind_ad(url)
+            || misc_ad_related(url)
+            || privacy::is_privacy_hard_url(url))
+}
+
+fn is_critical_allowlisted(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "/license/user",
+            "/product_state/get",
+            "/subscription/status",
+            "/user/product",
+            "/subscription/validate",
+        ],
+    )
+}
+
+fn core_ad_endpoint(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "/ads/",
+            "sp://ads/v1/ads/",
+            "/v1/ads/",
+            "ad-logic",
+            "adlogic",
+            "adsegments",
+            "/adrequest",
+            "/ad-request",
+            "spotify.ads.esperanto.proto.",
+            "spotify.ads.proto.",
+            "VND.Spotify.Ads-Payload",
+            "injected-ad",
+        ],
+    )
+}
+
+fn audio_ad_content(url: &str) -> bool {
+    (url.contains("audio-fa.scdn.co")
+        && contains_any(url, &["/ad/", "/ads/", "_ad_", "/sponsored/"]))
+        || (url.contains("audio-ak.spotify.com.edgesuite.net") && url.contains("/ad"))
+        || (url.contains("audio-ak-spotify-com") && url.contains("/ad"))
+        || contains_any(url, &["/ad_audio/", "/sponsored_audio/"])
+}
+
+fn spotify_ad_domain(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "ads.spotify.com",
+            "adstudio.spotify.com",
+            "audio-ads.spotify.com",
+            "creativeservice-production",
+        ],
+    )
+}
+
+fn third_party_ad_network(url: &str) -> bool {
+    contains_any(
+        url,
+        &["pubads.google.com/ad", "doubleclick", "googleads", "adswizz"],
+    )
+}
+
+fn podcast_ad_or_tracking(url: &str) -> bool {
+    url.contains("megaphone.fm")
+        || url.contains("art19.com")
+        || (url.contains("simplecast.com") && url.contains("episodes"))
+        || contains_any(url, &["chartable.com", "podsights.com", "podscribe.com"])
+}
+
+fn ad_specific_analytics(url: &str) -> bool {
+    (url.contains("analytics") && contains_any(url, &["ad", "sponsor", "promotion"]))
+        || contains_any(url, &["branch.io", "app.link", "adjust.com", "kochava.com"])
+        || (url.contains("clientsettings")
+            && url.contains("api")
+            && contains_any(url, &["ad", "sponsor", "promotion"]))
+        || (url.contains("track") && url.contains("event") && url.contains("ad"))
+}
+
+fn sponsored_or_promoted_content(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "sponsor",
+            "/promotion/",
+            "spotify:promotion:",
+            "/partner/",
+            "spotify:partner:",
+            "partnership",
+            "promoted",
+        ],
+    )
+}
+
+fn display_video_or_creative_ad(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "companion-ad",
+            "companion_content",
+            "companion-content",
+            "canvas_ad",
+            "canvas-ad",
+            "/figs/",
+            "video-ad",
+            "videoad",
+            "/ad.mp4",
+            "/ads.mp4",
+            "video-fa.scdn.co",
+            "canvasVideo",
+            "ad-creative",
+            "ad_creative",
+        ],
+    ) || (url.contains("/canvas/") && url.contains("ad"))
+}
+
+fn skip_limit_or_restriction(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "RemainingSkipsRequest",
+            "RemainingSkipsResponse",
+            "skip-limit",
+            "skip_limit",
+            "/v1/me/player/skip-limits",
+            "/skip-counter",
+            "/playback/restrictions",
+        ],
+    )
+}
+
+fn display_segment_ad(url: &str) -> bool {
+    contains_any(
+        url,
+        &["display-segments", "display_segments", "DisplaySegments"],
+    ) && contains_any(url, &["sponsor", "promoted", "ad"])
+}
+
+fn metadata_queue_or_playlist_ad(url: &str) -> bool {
+    (url.contains("/track-metadata") && url.contains("ad"))
+        || (url.contains("/resolve") && url.contains("spotify:ad:"))
+        || (url.contains("/metadata") && url.contains("injected"))
+        || (url.contains("/queue/add") && url.contains("ad"))
+        || (url.contains("/playlist/modify")
+            && contains_any(url, &["ad", "injected", "sponsor"]))
+        || contains_any(
+            url,
+            &[
+                "/playlist/decoration",
+                "/playlist/branding",
+                "/playlist/sponsor-info",
+            ],
+        )
+        || (url.contains("/v1/views/") && url.contains("sponsored"))
+        || (url.contains("i.scdn.co") && url.contains("sponsor"))
+        || (url.contains("mosaic.scdn.co") && url.contains("promo"))
+}
+
+fn entitlement_ad_check(url: &str) -> bool {
+    (url.contains("/license/") && url.contains("ad"))
+        || (url.contains("/entitlement/") && contains_any(url, &["ad", "sponsor"]))
+}
+
+fn gabo_ad_event(url: &str) -> bool {
+    url.contains("gabo-receiver-service")
+        && contains_any(
+            url,
+            &[
+                "/advertisement",
+                "/ad-opportunity",
+                "/adlogic",
+                "/ads",
+                "/v3/events/",
+                "/public/v3/events/",
+            ],
+        )
+}
+
+fn concert_location_tracking(url: &str) -> bool {
+    contains_any(
+        url,
+        &["concert_location", "concert-location", "concertLocation"],
+    )
+}
+
+fn leavebehind_ad(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "leavebehind",
+            "leave-behind",
+            "leave_behind",
+            "podcast-ap4p/leavebehind",
+            "podcast-ap4p/leavebehinds",
+            "podcast-ap4p",
+            "/ap4p/",
+            "sponsoredplaylist",
+            "aet.spotify.com",
+            "USE_GET_LEAVEBEHIND_ADS",
+            "leavebehindAds",
+            "leavebehinds-wrapper",
+            "leavebehinds-list",
+        ],
+    ) || (url.contains("graphql")
+        && contains_any(url, &["leavebehind", "getLeavebehind", "GetLeavebehind"]))
+}
+
+fn misc_ad_related(url: &str) -> bool {
+    ((url.contains("brand") || url.contains("branding"))
+        && contains_any(
+            url,
+            &["/sponsor", "/promotion", "/partner", "/playlist", "/ad"],
+        ))
+        || contains_any(url, &["whatsapp", "hpto", "takeover"])
+}

--- a/spotify-adblock/src/hooks/rules/ad.rs
+++ b/spotify-adblock/src/hooks/rules/ad.rs
@@ -1,5 +1,5 @@
 use super::ida;
-use super::matchers::contains_any;
+use super::matchers::{contains_any, is_spotify_client_url};
 use super::privacy;
 
 pub(in crate::hooks) fn is_ad_related_url(url: &str) -> bool {
@@ -143,13 +143,18 @@ fn skip_limit_or_restriction(url: &str) -> bool {
         &[
             "RemainingSkipsRequest",
             "RemainingSkipsResponse",
-            "skip-limit",
-            "skip_limit",
-            "/v1/me/player/skip-limits",
-            "/skip-counter",
-            "/playback/restrictions",
         ],
-    )
+    ) || (is_spotify_client_url(url)
+        && contains_any(
+            url,
+            &[
+                "skip-limit",
+                "skip_limit",
+                "/v1/me/player/skip-limits",
+                "/skip-counter",
+                "/playback/restrictions",
+            ],
+        ))
 }
 
 fn display_segment_ad(url: &str) -> bool {

--- a/spotify-adblock/src/hooks/rules/ida.rs
+++ b/spotify-adblock/src/hooks/rules/ida.rs
@@ -60,9 +60,34 @@ fn ad_tracking_attribution(url: &str) -> bool {
 }
 
 fn ad_stream_reporting(url: &str) -> bool {
-    (url.contains("stream_reporting")
-        && (url.contains("ad") || url.contains("sponsor") || url.contains("promotion")))
-        || (url.contains("stream-reporting") && (url.contains("ad") || url.contains("sponsor")))
+    (url.contains("stream_reporting") || url.contains("stream-reporting"))
+        && stream_reporting_ad_marker(url)
+}
+
+fn stream_reporting_ad_marker(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "/ad/",
+            "/ads/",
+            "/ad-",
+            "/ad_",
+            "/ad.",
+            "_ad_",
+            "-ad-",
+            ".ad.",
+            ":ad:",
+            "ad-event",
+            "ad_event",
+            "adEvent",
+            "AdEvent",
+            "AdDecision",
+            "audio_ad",
+            "sponsor",
+            "promotion",
+            "promoted",
+        ],
+    )
 }
 
 fn legacy_ida_ad_signal(url: &str) -> bool {
@@ -113,5 +138,21 @@ mod tests {
     fn leaves_spotify_client_specific_routes_host_scoped() {
         assert!(!is_ida_ad_signal("https://example.com/v1/podcast/nextAdSegment"));
         assert!(!is_ida_ad_signal("https://example.com/foo/partner-userid"));
+    }
+
+    #[test]
+    fn stream_reporting_uses_explicit_ad_markers() {
+        assert!(is_ida_ad_signal(
+            "https://spclient.wg.spotify.com/stream_reporting/ad-event"
+        ));
+        assert!(is_ida_ad_signal(
+            "https://spclient.wg.spotify.com/stream-reporting/sponsor"
+        ));
+        assert!(!is_ida_ad_signal(
+            "https://spclient.wg.spotify.com/stream_reporting/metadata"
+        ));
+        assert!(!is_ida_ad_signal(
+            "https://spclient.wg.spotify.com/stream_reporting/download"
+        ));
     }
 }

--- a/spotify-adblock/src/hooks/rules/ida.rs
+++ b/spotify-adblock/src/hooks/rules/ida.rs
@@ -1,0 +1,101 @@
+use super::matchers::contains_any;
+
+pub(super) fn is_ida_ad_signal(url: &str) -> bool {
+    ad_event_reporting(url)
+        || podcast_ad_segment(url)
+        || ad_pod_or_decision_tree(url)
+        || esperanto_ad_service(url)
+        || ad_tracking_attribution(url)
+        || ad_stream_reporting(url)
+        || legacy_ida_ad_signal(url)
+}
+
+fn ad_event_reporting(url: &str) -> bool {
+    url.contains("audio_ad_event_reporter")
+        || url.contains("/AdEvent")
+        || url.contains("/EndAd")
+        || url.contains("/AdDecisionEvent")
+        || url.contains("/AdRequestEvent")
+        || url.contains("/AdTransparencyEvent")
+        || url.contains("/AdDetectionResult")
+}
+
+fn podcast_ad_segment(url: &str) -> bool {
+    url.contains("/PodcastAdSegment")
+        || url.contains("/GetNextAdSegment")
+        || url.contains("nextAdSegment")
+        || url.contains("AdSegmentsMetadataReceived")
+}
+
+fn ad_pod_or_decision_tree(url: &str) -> bool {
+    url.contains("/AdPodResponse") || url.contains("/AdDecisionTree")
+}
+
+fn esperanto_ad_service(url: &str) -> bool {
+    url.contains("esperanto")
+        && (url.contains("/ads/")
+            || url.contains("/Ads")
+            || url.contains("AdOpportunity")
+            || url.contains("PodcastAds")
+            || url.contains("/Targeting")
+            || url.contains("/ad-")
+            || url.contains("_ad_"))
+}
+
+fn ad_tracking_attribution(url: &str) -> bool {
+    url.contains("/branch_io")
+        || url.contains("/branchIo")
+        || url.contains("branch-io")
+        || url.contains("/partner_user_id")
+        || url.contains("/partner-user-id")
+        || url.contains("partner-userid")
+        || url.contains("partnerUserId")
+}
+
+fn ad_stream_reporting(url: &str) -> bool {
+    (url.contains("stream_reporting")
+        && (url.contains("ad") || url.contains("sponsor") || url.contains("promotion")))
+        || (url.contains("stream-reporting") && (url.contains("ad") || url.contains("sponsor")))
+}
+
+fn legacy_ida_ad_signal(url: &str) -> bool {
+    contains_any(
+        url,
+        &[
+            "open.spotify.com/ad/",
+            "spotify:ad:",
+            "open.spotify.com/interruption/",
+            "spotify:interruption:",
+            "open.spotify.com/promotion/",
+            "contains_sponsored_content",
+            "SponsoredContentListenerPayload",
+            "PODCAST_SPONSORED_CONTENT",
+            "slot_has_active_ad",
+            "slot_fetching_turned_off",
+            "PrepareSlotRequest",
+            "AdPodResponse",
+            "SlotRealtimeDecisions",
+            "audio_ad_event",
+            "viewable_impression",
+            "fire_impression_on_end",
+            "tracking_events",
+            "trackingEvents",
+            "PROMO_V1_TRAIT",
+            "PROMO_V3_TRAIT",
+            "AUDIOBOOK_PROMOTION",
+        ],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_ida_ad_misses_when_present() {
+        assert!(is_ida_ad_signal("/v1/podcast/nextAdSegment"));
+        assert!(is_ida_ad_signal(
+            "https://spclient.wg.spotify.com/foo/partner-userid/encrypted/bar"
+        ));
+    }
+}

--- a/spotify-adblock/src/hooks/rules/ida.rs
+++ b/spotify-adblock/src/hooks/rules/ida.rs
@@ -1,4 +1,4 @@
-use super::matchers::contains_any;
+use super::matchers::{contains_any, is_spotify_client_url};
 
 pub(super) fn is_ida_ad_signal(url: &str) -> bool {
     ad_event_reporting(url)
@@ -14,6 +14,7 @@ fn ad_event_reporting(url: &str) -> bool {
     url.contains("audio_ad_event_reporter")
         || url.contains("/AdEvent")
         || url.contains("/EndAd")
+        || url.contains("/AdDecision")
         || url.contains("/AdDecisionEvent")
         || url.contains("/AdRequestEvent")
         || url.contains("/AdTransparencyEvent")
@@ -23,7 +24,7 @@ fn ad_event_reporting(url: &str) -> bool {
 fn podcast_ad_segment(url: &str) -> bool {
     url.contains("/PodcastAdSegment")
         || url.contains("/GetNextAdSegment")
-        || url.contains("nextAdSegment")
+        || (is_spotify_client_url(url) && url.contains("nextAdSegment"))
         || url.contains("AdSegmentsMetadataReceived")
 }
 
@@ -46,10 +47,16 @@ fn ad_tracking_attribution(url: &str) -> bool {
     url.contains("/branch_io")
         || url.contains("/branchIo")
         || url.contains("branch-io")
-        || url.contains("/partner_user_id")
-        || url.contains("/partner-user-id")
-        || url.contains("partner-userid")
-        || url.contains("partnerUserId")
+        || (is_spotify_client_url(url)
+            && contains_any(
+                url,
+                &[
+                    "/partner_user_id",
+                    "/partner-user-id",
+                    "partner-userid",
+                    "partnerUserId",
+                ],
+            ))
 }
 
 fn ad_stream_reporting(url: &str) -> bool {
@@ -93,9 +100,18 @@ mod tests {
 
     #[test]
     fn detects_ida_ad_misses_when_present() {
-        assert!(is_ida_ad_signal("/v1/podcast/nextAdSegment"));
+        assert!(is_ida_ad_signal(
+            "https://spclient.wg.spotify.com/v1/podcast/nextAdSegment"
+        ));
         assert!(is_ida_ad_signal(
             "https://spclient.wg.spotify.com/foo/partner-userid/encrypted/bar"
         ));
+        assert!(is_ida_ad_signal("/AdDecision"));
+    }
+
+    #[test]
+    fn leaves_spotify_client_specific_routes_host_scoped() {
+        assert!(!is_ida_ad_signal("https://example.com/v1/podcast/nextAdSegment"));
+        assert!(!is_ida_ad_signal("https://example.com/foo/partner-userid"));
     }
 }

--- a/spotify-adblock/src/hooks/rules/matchers.rs
+++ b/spotify-adblock/src/hooks/rules/matchers.rs
@@ -3,7 +3,26 @@ pub(super) fn contains_any(url: &str, needles: &[&str]) -> bool {
 }
 
 pub(super) fn is_spotify_client_url(url: &str) -> bool {
-    url.contains("spclient.wg.spotify.com") || url.contains("-spclient.spotify.com")
+    url_host(url).is_some_and(is_spotify_client_host)
+}
+
+fn url_host(url: &str) -> Option<&str> {
+    let (_, rest) = url.split_once("://")?;
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host_port)| host_port);
+    let host = host_port.split_once(':').map_or(host_port, |(host, _)| host);
+    Some(host.trim_end_matches('.'))
+}
+
+fn is_spotify_client_host(host: &str) -> bool {
+    const SPCLIENT_SUFFIX: &str = "-spclient.spotify.com";
+
+    host.eq_ignore_ascii_case("spclient.wg.spotify.com")
+        || host
+            .get(host.len().saturating_sub(SPCLIENT_SUFFIX.len())..)
+            .is_some_and(|tail| tail.eq_ignore_ascii_case(SPCLIENT_SUFFIX))
 }
 
 #[cfg(test)]
@@ -19,7 +38,15 @@ mod tests {
     #[test]
     fn spotify_client_url_matches_known_client_hosts() {
         assert!(is_spotify_client_url("https://spclient.wg.spotify.com/foo"));
+        assert!(is_spotify_client_url("https://spclient.wg.spotify.com:443/foo"));
+        assert!(is_spotify_client_url("https://SPCLIENT.WG.SPOTIFY.COM/foo"));
         assert!(is_spotify_client_url("https://gae2-spclient.spotify.com/foo"));
         assert!(!is_spotify_client_url("https://example.com/foo"));
+        assert!(!is_spotify_client_url(
+            "https://spclient.wg.spotify.com.evil.tld/foo"
+        ));
+        assert!(!is_spotify_client_url(
+            "https://example.com/?next=https://spclient.wg.spotify.com/foo"
+        ));
     }
 }

--- a/spotify-adblock/src/hooks/rules/matchers.rs
+++ b/spotify-adblock/src/hooks/rules/matchers.rs
@@ -1,0 +1,3 @@
+pub(super) fn contains_any(url: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| url.contains(needle))
+}

--- a/spotify-adblock/src/hooks/rules/matchers.rs
+++ b/spotify-adblock/src/hooks/rules/matchers.rs
@@ -1,3 +1,25 @@
 pub(super) fn contains_any(url: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| url.contains(needle))
 }
+
+pub(super) fn is_spotify_client_url(url: &str) -> bool {
+    url.contains("spclient.wg.spotify.com") || url.contains("-spclient.spotify.com")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains_any_matches_any_needle() {
+        assert!(contains_any("https://example.com/ads/foo", &["/ads/", "/metrics/"]));
+        assert!(!contains_any("https://example.com/tracks/foo", &["/ads/", "/metrics/"]));
+    }
+
+    #[test]
+    fn spotify_client_url_matches_known_client_hosts() {
+        assert!(is_spotify_client_url("https://spclient.wg.spotify.com/foo"));
+        assert!(is_spotify_client_url("https://gae2-spclient.spotify.com/foo"));
+        assert!(!is_spotify_client_url("https://example.com/foo"));
+    }
+}

--- a/spotify-adblock/src/hooks/rules/mod.rs
+++ b/spotify-adblock/src/hooks/rules/mod.rs
@@ -1,0 +1,7 @@
+mod ad;
+mod ida;
+mod matchers;
+mod privacy;
+
+pub(super) use ad::is_ad_related_url;
+pub(super) use privacy::is_privacy_hard_url;

--- a/spotify-adblock/src/hooks/rules/mod.rs
+++ b/spotify-adblock/src/hooks/rules/mod.rs
@@ -3,5 +3,7 @@ mod ida;
 mod matchers;
 mod privacy;
 
+#[cfg(test)]
+mod tests;
+
 pub(super) use ad::is_ad_related_url;
-pub(super) use privacy::is_privacy_hard_url;

--- a/spotify-adblock/src/hooks/rules/privacy.rs
+++ b/spotify-adblock/src/hooks/rules/privacy.rs
@@ -1,0 +1,93 @@
+#[cfg(feature = "privacy-hard-blocking")]
+pub(in crate::hooks) fn is_privacy_hard_url(url: &str) -> bool {
+    privacy_hard_telemetry(url)
+}
+
+#[cfg(not(feature = "privacy-hard-blocking"))]
+pub(in crate::hooks) const fn is_privacy_hard_url(_url: &str) -> bool {
+    false
+}
+
+#[cfg(feature = "privacy-hard-blocking")]
+fn privacy_hard_telemetry(url: &str) -> bool {
+    logging_route(url)
+        || event_sender_route(url)
+        || pending_events_route(url)
+        || stream_reporting_route(url)
+        || remote_config_route(url)
+        || common_capping_route(url)
+}
+
+#[cfg(feature = "privacy-hard-blocking")]
+fn logging_route(url: &str) -> bool {
+    url.contains("hm://event-service/v1/events")
+        || url.contains("/event-service/v1/events")
+        || url.contains("sp://logging/v1/")
+        || url.contains("sp://logging/v2/")
+        || url.contains("sp://logging/v3/")
+        || url.contains("/logging/v1/")
+        || url.contains("/logging/v2/")
+        || url.contains("/logging/v3/")
+}
+
+#[cfg(feature = "privacy-hard-blocking")]
+fn event_sender_route(url: &str) -> bool {
+    url.contains("event_sender")
+        || url.contains("event-sender")
+        || url.contains("Event-sender")
+        || url.contains("/Event-sender/")
+}
+
+#[cfg(feature = "privacy-hard-blocking")]
+fn pending_events_route(url: &str) -> bool {
+    url.contains("pending_events")
+        || url.contains("pending-events")
+        || url.contains("PendingEvents")
+}
+
+#[cfg(feature = "privacy-hard-blocking")]
+fn stream_reporting_route(url: &str) -> bool {
+    url.contains("stream_reporting")
+        || url.contains("stream-reporting")
+        || url.contains("StreamReporting")
+}
+
+#[cfg(feature = "privacy-hard-blocking")]
+fn remote_config_route(url: &str) -> bool {
+    url.contains("remote_config")
+        || url.contains("remote-config")
+        || url.contains("RemoteConfig")
+}
+
+#[cfg(feature = "privacy-hard-blocking")]
+fn common_capping_route(url: &str) -> bool {
+    url.contains("commoncapping")
+        || url.contains("common_capping")
+        || url.contains("consumptionevent")
+        || url.contains("ConsumptionEvent")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(not(feature = "privacy-hard-blocking"))]
+    fn keeps_privacy_hard_routes_enabled_by_feature_only() {
+        assert!(!is_privacy_hard_url("hm://event-service/v1/events"));
+        assert!(!is_privacy_hard_url("sp://logging/v2/foo"));
+        assert!(!is_privacy_hard_url("spotify.pending_events.esperanto.proto.PendingEvents"));
+    }
+
+    #[test]
+    #[cfg(feature = "privacy-hard-blocking")]
+    fn detects_privacy_hard_routes_when_feature_enabled() {
+        assert!(is_privacy_hard_url("hm://event-service/v1/events"));
+        assert!(is_privacy_hard_url("sp://logging/v3/foo"));
+        assert!(is_privacy_hard_url("spotify.event_sender.proto.EventCounters"));
+        assert!(is_privacy_hard_url("spotify.pending_events.esperanto.proto.PendingEvents"));
+        assert!(is_privacy_hard_url("spotify.stream_reporting_esperanto.proto.StreamReporting"));
+        assert!(is_privacy_hard_url("spotify.remote_config.esperanto.proto.RemoteConfig"));
+        assert!(is_privacy_hard_url("commoncapping/consumptionevent"));
+    }
+}

--- a/spotify-adblock/src/hooks/rules/privacy.rs
+++ b/spotify-adblock/src/hooks/rules/privacy.rs
@@ -28,7 +28,10 @@ fn logging_route(url: &str) -> bool {
 
 #[cfg(feature = "privacy-hard-blocking")]
 fn event_sender_route(url: &str) -> bool {
-    url.contains("event_sender") || url.contains("event-sender") || url.contains("Event-sender")
+    url.contains("event_sender")
+        || url.contains("event-sender")
+        || url.contains("EventSender")
+        || url.contains("Event-sender")
 }
 
 #[cfg(feature = "privacy-hard-blocking")]
@@ -78,6 +81,7 @@ mod tests {
         assert!(is_privacy_hard_url("hm://event-service/v1/events"));
         assert!(is_privacy_hard_url("sp://logging/v3/foo"));
         assert!(is_privacy_hard_url("spotify.event_sender.proto.EventCounters"));
+        assert!(is_privacy_hard_url("spotify.event_sender.proto.EventSender"));
         assert!(is_privacy_hard_url("spotify.pending_events.esperanto.proto.PendingEvents"));
         assert!(is_privacy_hard_url("spotify.stream_reporting_esperanto.proto.StreamReporting"));
         assert!(is_privacy_hard_url("spotify.remote_config.esperanto.proto.RemoteConfig"));

--- a/spotify-adblock/src/hooks/rules/privacy.rs
+++ b/spotify-adblock/src/hooks/rules/privacy.rs
@@ -20,11 +20,7 @@ fn privacy_hard_telemetry(url: &str) -> bool {
 
 #[cfg(feature = "privacy-hard-blocking")]
 fn logging_route(url: &str) -> bool {
-    url.contains("hm://event-service/v1/events")
-        || url.contains("/event-service/v1/events")
-        || url.contains("sp://logging/v1/")
-        || url.contains("sp://logging/v2/")
-        || url.contains("sp://logging/v3/")
+    url.contains("/event-service/v1/events")
         || url.contains("/logging/v1/")
         || url.contains("/logging/v2/")
         || url.contains("/logging/v3/")
@@ -32,10 +28,7 @@ fn logging_route(url: &str) -> bool {
 
 #[cfg(feature = "privacy-hard-blocking")]
 fn event_sender_route(url: &str) -> bool {
-    url.contains("event_sender")
-        || url.contains("event-sender")
-        || url.contains("Event-sender")
-        || url.contains("/Event-sender/")
+    url.contains("event_sender") || url.contains("event-sender") || url.contains("Event-sender")
 }
 
 #[cfg(feature = "privacy-hard-blocking")]

--- a/spotify-adblock/src/hooks/rules/tests.rs
+++ b/spotify-adblock/src/hooks/rules/tests.rs
@@ -17,3 +17,13 @@ fn ad_rules_cover_sponsored_and_ida_paths() {
         "https://spclient.wg.spotify.com/v1/podcast/nextAdSegment"
     ));
 }
+
+#[test]
+fn ad_rules_scope_playback_restrictions_to_spotify_client_hosts() {
+    assert!(is_ad_related_url(
+        "https://spclient.wg.spotify.com/playback/restrictions"
+    ));
+    assert!(!is_ad_related_url(
+        "https://example.com/playback/restrictions"
+    ));
+}

--- a/spotify-adblock/src/hooks/rules/tests.rs
+++ b/spotify-adblock/src/hooks/rules/tests.rs
@@ -1,0 +1,19 @@
+use super::is_ad_related_url;
+
+#[test]
+fn ad_rules_cover_core_routes_and_allowlisted_license() {
+    assert!(is_ad_related_url("https://spclient.wg.spotify.com/v1/ads/foo"));
+    assert!(!is_ad_related_url(
+        "https://spclient.wg.spotify.com/license/user"
+    ));
+}
+
+#[test]
+fn ad_rules_cover_sponsored_and_ida_paths() {
+    assert!(is_ad_related_url(
+        "https://open.spotify.com/promotion/campaign"
+    ));
+    assert!(is_ad_related_url(
+        "https://spclient.wg.spotify.com/v1/podcast/nextAdSegment"
+    ));
+}

--- a/spotify-adblock/src/hooks/ssl.rs
+++ b/spotify-adblock/src/hooks/ssl.rs
@@ -26,6 +26,14 @@ static SSL_VERBOSE: LazyLock<AtomicBool> = LazyLock::new(|| AtomicBool::new(fals
 
 const MAX_INSPECT_LEN: usize = 4096;
 
+fn is_spotify_client_host(host: &str) -> bool {
+    let host = host.strip_suffix(":443").unwrap_or(host);
+    host.eq_ignore_ascii_case("spclient.wg.spotify.com")
+        || host
+            .get(host.len().saturating_sub("-spclient.spotify.com".len())..)
+            .is_some_and(|tail| tail.eq_ignore_ascii_case("-spclient.spotify.com"))
+}
+
 fn should_block_ssl_request(data: &[u8]) -> Option<String> {
     let header_len = data
         .windows(4)
@@ -54,6 +62,7 @@ fn should_block_ssl_request(data: &[u8]) -> Option<String> {
         .map_or("unknown", |line| line[5..].trim());
 
     let url = format!("https://{host}{path}");
+    let is_spotify_client_host = is_spotify_client_host(host);
 
     // Ad blocking patterns - endpoints that bypass CEF
     let is_ad_related =
@@ -86,14 +95,16 @@ fn should_block_ssl_request(data: &[u8]) -> Option<String> {
         // Partner/attribution tracking
         host.contains("branch.io") ||
         host.contains("adjust.com") ||
-        path.contains("/partner_user_id") ||
-        path.contains("partner-userid") ||
+        (is_spotify_client_host && (
+            path.contains("/partner_user_id") ||
+            path.contains("partner-userid")
+        )) ||
         // Podcast ad networks
         host.contains("megaphone.fm") ||
         host.contains("art19.com") ||
         host.contains("chartable.com") ||
         host.contains("podsights.com") ||
-        path.contains("nextAdSegment") ||
+        (is_spotify_client_host && path.contains("nextAdSegment")) ||
         // Display ad segments
         (path.contains("display-segments") && path.contains("sponsor")) ||
         // Ad event reporting
@@ -104,7 +115,7 @@ fn should_block_ssl_request(data: &[u8]) -> Option<String> {
         path.contains("skip-limit") ||
         path.contains("skip_limit") ||
         path.contains("/playback/restrictions") ||
-        rules::is_privacy_hard_url(&url);
+        rules::is_ad_related_url(&url);
 
     if is_ad_related {
         Some(format!("{method} {url}"))
@@ -148,4 +159,30 @@ pub fn enable_verbose_logging() {
 #[allow(dead_code)]
 pub fn disable_verbose_logging() {
     SSL_VERBOSE.store(false, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(host: &str, path: &str) -> Vec<u8> {
+        format!("GET {path} HTTP/1.1\r\nHost: {host}\r\n\r\n").into_bytes()
+    }
+
+    #[test]
+    fn blocks_ida_spotify_client_routes_from_ssl() {
+        assert!(should_block_ssl_request(&request(
+            "spclient.wg.spotify.com",
+            "/v1/podcast/nextAdSegment"
+        ))
+        .is_some());
+    }
+
+    #[test]
+    fn leaves_spotify_client_routes_host_scoped() {
+        assert!(should_block_ssl_request(&request("example.com", "/v1/podcast/nextAdSegment"))
+            .is_none());
+        assert!(should_block_ssl_request(&request("example.com", "/foo/partner-userid"))
+            .is_none());
+    }
 }

--- a/spotify-adblock/src/hooks/ssl.rs
+++ b/spotify-adblock/src/hooks/ssl.rs
@@ -112,9 +112,11 @@ fn should_block_ssl_request(data: &[u8]) -> Option<String> {
         path.contains("/EndAd") ||
         path.contains("/AdDecision") ||
         // Skip limits
-        path.contains("skip-limit") ||
-        path.contains("skip_limit") ||
-        path.contains("/playback/restrictions") ||
+        (is_spotify_client_host && (
+            path.contains("skip-limit") ||
+            path.contains("skip_limit") ||
+            path.contains("/playback/restrictions")
+        )) ||
         rules::is_ad_related_url(&url);
 
     if is_ad_related {
@@ -184,5 +186,16 @@ mod tests {
             .is_none());
         assert!(should_block_ssl_request(&request("example.com", "/foo/partner-userid"))
             .is_none());
+        assert!(should_block_ssl_request(&request("example.com", "/playback/restrictions"))
+            .is_none());
+    }
+
+    #[test]
+    fn blocks_spotify_client_playback_restrictions_from_ssl() {
+        assert!(should_block_ssl_request(&request(
+            "spclient.wg.spotify.com",
+            "/playback/restrictions"
+        ))
+        .is_some());
     }
 }

--- a/spotify-adblock/src/hooks/ssl.rs
+++ b/spotify-adblock/src/hooks/ssl.rs
@@ -14,6 +14,8 @@ use crate::config::DEBUG_MODE;
 use crate::hook;
 use crate::utils::logging;
 
+use super::rules;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SSL {
@@ -85,11 +87,13 @@ fn should_block_ssl_request(data: &[u8]) -> Option<String> {
         host.contains("branch.io") ||
         host.contains("adjust.com") ||
         path.contains("/partner_user_id") ||
+        path.contains("partner-userid") ||
         // Podcast ad networks
         host.contains("megaphone.fm") ||
         host.contains("art19.com") ||
         host.contains("chartable.com") ||
         host.contains("podsights.com") ||
+        path.contains("nextAdSegment") ||
         // Display ad segments
         (path.contains("display-segments") && path.contains("sponsor")) ||
         // Ad event reporting
@@ -99,7 +103,8 @@ fn should_block_ssl_request(data: &[u8]) -> Option<String> {
         // Skip limits
         path.contains("skip-limit") ||
         path.contains("skip_limit") ||
-        path.contains("/playback/restrictions");
+        path.contains("/playback/restrictions") ||
+        rules::is_privacy_hard_url(&url);
 
     if is_ad_related {
         Some(format!("{method} {url}"))


### PR DESCRIPTION
## **User description**
## Summary
- add opt-in `privacy-hard-blocking` Cargo feature for broad Spotify telemetry routes from the IDA dump
- split URL rules into typed modules under `hooks/rules/` by default ad rules, IDA-derived ad signals, shared matchers, and hard privacy rules
- keep safe ad-specific misses enabled by default for `partner-userid/encrypted` and `/v1/podcast/nextAdSegment`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo build --release --lib -p spotify-adblock --features privacy-hard-blocking`
- `cargo +nightly miri test -p spotify-adblock --lib --features privacy-hard-blocking`
- `codegraph index`

LSP diagnostics could not run locally because the LSP transport closed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `privacy-hard-blocking` mode in `spotify-adblock` to block broad Spotify telemetry, and tightens ad rules with shared matchers and host-scoped SSL enforcement. CI now auto-resolves and verifies the correct CEF binary; Clippy MSRV aligned to 1.85.

- **New Features**
  - Added `privacy-hard-blocking` feature flag to block event-service, logging (v1–v3), event sender, pending events, stream reporting, remote config, and common capping; may impact Wrapped, history, recommendations, or diagnostics.
  - Enforcement wired into URL classification and SSL; README includes build command: cargo build -p `spotify-adblock` --features `privacy-hard-blocking`.
  - Default denylist expanded to block `partner-userid/encrypted` and `/v1/podcast/nextAdSegment` (including `*-spclient.spotify.com`).

- **Refactors**
  - Split rules into `hooks/rules/{ad, ida, privacy, matchers}.rs`; simplified `request_classification.rs` with shared matchers and tests; fixed boundary cases (long URLs, host scoping for `spclient`).
  - SSL hook delegates to shared rules and host-scopes IDA routes and playback restrictions for `spclient` (e.g., `nextAdSegment`, `partner-userid`, `playback/restrictions`), with tests.
  - CI resolves and caches the correct CEF archive with SHA1 verification; `cef-sys` wrapper now includes only present CAPI headers; Clippy MSRV set to 1.85.

<sup>Written for commit 936da40c596dd275f2cbc093417e35343db80a5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/coleleavitt/spotify-adblock/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional "Privacy hard build" mode that blocks additional Spotify telemetry routes beyond standard ad blocking.
  * Note: This mode may impact Wrapped, listening history, recommendations, and diagnostics.

* **Bug Fixes**
  * Enhanced blocking for additional Spotify ad domains and podcast ad endpoints.
  * Improved detection of ad-related and telemetry requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add an opt-in privacy mode that blocks Spotify telemetry routes**

### What Changed
- Added an optional privacy mode that blocks broad telemetry traffic such as event logging, event sending, pending events, stream reporting, remote config, and common capping routes
- Expanded blocking to catch additional Spotify client routes for podcast ad segments and partner user IDs, and applied the same protection in the SSL layer
- Kept premium validation routes allowed, while preserving the default behavior unless the new feature is enabled
- Added checks and coverage for the new blocked routes, plus a safer build path for CEF downloads and extraction

### Impact
`✅ Fewer Spotify telemetry requests`
`✅ Less exposure of listening activity data`
`✅ Fewer blocked premium validation checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
